### PR TITLE
Got rid of the setTheme() call that sets the background of the SignIn…

### DIFF
--- a/app/src/main/java/com/brentdunklau/telepatriot_android/MainActivity.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/MainActivity.java
@@ -51,8 +51,7 @@ public class MainActivity extends AppCompatActivity
                             new AuthUI.IdpConfig.Builder(AuthUI.GOOGLE_PROVIDER).build(),
                             new AuthUI.IdpConfig.Builder(AuthUI.EMAIL_PROVIDER).build()
                             )
-                    )
-                    .setTheme(R.style.FlagTheme);
+                    );
 
             Intent intent = sib.build();
             intent.putExtra("backgroundImage", R.drawable.usflag);


### PR DESCRIPTION
… screen because the background made it hard to see the email field for email signup's.  So we're back to just a white background on the signup screen.