### PR TITLE
Finally got the role and topic triggers to work all the way - adding …

### DIFF
--- a/firebase-functions/functions/index.js
+++ b/firebase-functions/functions/index.js
@@ -14,3 +14,4 @@ exports.notifyUserCreated = notifications.notifyUserCreated
 exports.roleAssigned = roles.roleAssigned
 exports.roleUnassigned = roles.roleUnassigned
 exports.topicCreated = topics.topicCreated
+exports.topicDeleted = topics.topicDeleted

--- a/firebase-functions/functions/roles.js
+++ b/firebase-functions/functions/roles.js
@@ -9,41 +9,61 @@ exports.roleAssigned = functions.database.ref('/users/{uid}/roles/{role}').onWri
     var evtsnapshot = event.data
     console.log("roleAssigned: uid=", event.params.uid, "role=", event.params.role)
 
-    // event.params.role will be the value of the key so make the key 'Admin' and the value doesn't matter
+    // Only edit data when it is first created.
+    if (event.data.previous.exists()) {
+        return;
+    }
+    // Exit when the data is deleted.
+    if (!event.data.exists()) {
+        return;
+    }
 
-    event.data.adminRef.root.child('/roles/'+event.params.role+'/users').push(event.params.uid)
+    // event.params.role will be the value of the key so make the key 'Admin' and the value doesn't matter
+    var uid = event.params.uid
+    var role = event.params.role
+
+    event.data.adminRef.root.child(`/users/${uid}`).once('value').then(snapshot => {
+        console.log("snapshot.val(): ", snapshot.val())
+        event.data.adminRef.root.child(`/roles/${role}/users/${uid}`)
+            .set({name: snapshot.val().name, email: snapshot.val().email})
+    })
+
 
     // now need to get the topics associated with this role
-    /*****/
-    return event.data.adminRef.root.child('/roles/'+event.params.role+'/topics').once('value').then(snapshot => {
+    return event.data.adminRef.root.child(`/roles/${role}/topics`).once('value').then(snapshot => {
           snapshot.forEach(function(child) {
             console.log("child.val(): ", child.val())
             var topic = child.val().name
-            event.data.adminRef.root.child('/users/'+event.params.uid+'/topics').child(topic).set('true')
+            event.data.adminRef.root.child(`/users/${uid}/topics`).child(topic).set('true')
           });
     })
-    /*****/
+
 });
 
 
 
 exports.roleUnassigned = functions.database.ref('/users/{uid}/roles/{role}').onDelete( event => {
-    var evtsnapshot = event.data
-    console.log("roleAssigned: uid=", event.params.uid, "role=", event.params.role)
+    console.log("roleUnassigned: uid=", event.params.uid, "role=", event.params.role)
+    // this is the DatabaseSnapshot object
+    //var evtsnapshot = event.data.previous
 
-    // event.params.role will be the value of the key so make the key 'Admin' and the value doesn't matter
+    var role = event.params.role
+    var uid = event.params.uid
 
-    // now need to get the topics associated with this role
-    /*****/
-    return event.data.adminRef.root.child('/roles/'+event.params.role+'/topics').once('value').then(snapshot => {
+    event.data.previous.adminRef.root.child(`/roles/${role}/users/${uid}`).remove()
+
+    return event.data.adminRef.root.child(`/roles/${role}/topics`).once('value').then(snapshot => {
+
           snapshot.forEach(function(child) {
             console.log("child.val(): ", child.val())
             var topic = child.val().name
-            event.data.adminRef.root.child('/users/'+event.params.uid+'/topics').child(topic).remove()
+            event.data.adminRef.root.child(`/users/${uid}/topics/${topic}`).remove()
           });
+
     })
-    /*****/
+
 });
+
 
 
 

--- a/firebase-functions/functions/userCreated.js
+++ b/firebase-functions/functions/userCreated.js
@@ -19,8 +19,9 @@ exports.createUserAccount = functions.auth.user().onCreate(event => {
 
     console.log("userCreated.js: onCreate returning...")
 
-    var userrecord = {photoUrl:photoUrl, email:email}
-    if(event.data.displayName) userrecord.name = event.data.displayName
+    var name = email // default value if name not present
+    if(event.data.displayName) name = event.data.displayName
+    var userrecord = {name:name, photoUrl:photoUrl, email:email}
 
     // remember, .set() returns a promise
     return newUserRef.set(userrecord)


### PR DESCRIPTION
…and deleting a role for a person, and adding and deleting a topic associated with a role.

If you add a role to a person's node, the triggers will look in the db tree to see what topics are associated with that role, and then those topics are added to the user's node.  If you add or delete a topic from the /roles/${role} node, the triggers will go find the users that have that role and then add/delete the topic from each of the user nodes.   So these triggers maintain the integrity of the data.

And if you delete a role from a person, the triggers will see what topics are associated with that role and remove those topics from the user's node - so just the opposite of what happens when a role is assigned to a user.

We also have a /roles/${role}/users node that keeps track of what users are associated with each role from a role standpoint.  This node is also automatically kept in sync by the triggers.