### PR TITLE
Moved some code from the various activity classes up to BaseActivity …

### DIFF
--- a/app/src/main/java/com/brentdunklau/telepatriot_android/AdminActivity.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/AdminActivity.java
@@ -2,6 +2,7 @@ package com.brentdunklau.telepatriot_android;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 
 import com.brentdunklau.telepatriot_android.com.brentdunklau.telepatriot_android.util.SlideIt;
 import com.brentdunklau.telepatriot_android.com.brentdunklau.telepatriot_android.util.SwipeAdapter;
@@ -13,52 +14,27 @@ import com.brentdunklau.telepatriot_android.com.brentdunklau.telepatriot_android
 
 public class AdminActivity extends BaseActivity implements SlideIt {
 
+    private final static String TAG = "AdminActivity";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_admin);
+        currentActivity = this.getClass();
         swipeAdapter = new SwipeAdapter(this, this);
         user = User.getInstance();
-    }
-
-    private Class onTheLeft() {
-        return user.activityOnTheLeft(AdminActivity.class);
-    }
-
-    private Class onTheRight() {
-        return user.activityOnTheRight(AdminActivity.class);
-    }
-
-
-    @Override
-    public void rightToLeft() {
-        Intent it = new Intent(this, onTheRight());
-        startActivity(it);
-        overridePendingTransition(R.anim.slide_from_right, R.anim.slide_to_left);
-    }
-
-    @Override
-    public void leftToRight() {
-        Intent it = new Intent(this, onTheLeft());
-        startActivity(it);
-        overridePendingTransition(R.anim.slide_from_left, R.anim.slide_to_right);
-    }
-/*
-    @Override
-    protected void onPause() {
-        super.onPause();
-        Log.d("AdminActivity", "paused");
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-        Log.d("AdminActivity", "resume");
+        currentActivity = this.getClass();
+        Log.d(TAG, "resume");
     }
 
     @Override
     protected void onStart() {
         super.onStart();
-        Log.d("AdminActivity", "start");
-    }*/
+        currentActivity = this.getClass();
+    }
 }

--- a/app/src/main/java/com/brentdunklau/telepatriot_android/BaseActivity.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/BaseActivity.java
@@ -1,5 +1,6 @@
 package com.brentdunklau.telepatriot_android;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
@@ -29,7 +30,7 @@ import com.google.firebase.database.ValueEventListener;
 public class BaseActivity extends AppCompatActivity {
 
 
-    protected String TAG = "BaseActivity";
+    private String TAG = "BaseActivity";
 
     // Firebase instance variables
     protected FirebaseAuth mFirebaseAuth;  // see https://codelabs.developers.google.com/codelabs/firebase-android/#5
@@ -37,6 +38,7 @@ public class BaseActivity extends AppCompatActivity {
     protected DatabaseReference myRef;
     protected SwipeAdapter swipeAdapter;
     protected User user;
+    protected Class currentActivity;
 
 
     @Override
@@ -143,5 +145,34 @@ public class BaseActivity extends AppCompatActivity {
         super.onStart();
         String cname = this.getClass().getName();
         Log.d(cname, "start");
+    }
+
+
+    private Class onTheLeft() {
+        return user.activityOnTheLeft(currentActivity);
+    }
+
+
+    private Class onTheRight() {
+        return user.activityOnTheRight(currentActivity);
+    }
+
+
+    public void rightToLeft() {
+        Class onTheRight = onTheRight();
+        if(onTheRight != null) {
+            Intent it = new Intent(this, onTheRight());
+            startActivity(it);
+            overridePendingTransition(R.anim.slide_from_right, R.anim.slide_to_left);
+        }
+    }
+
+    public void leftToRight() {
+        Class onTheLeft = onTheLeft();
+        if(onTheLeft != null) {
+            Intent it = new Intent(this, onTheLeft());
+            startActivity(it);
+            overridePendingTransition(R.anim.slide_from_left, R.anim.slide_to_right);
+        }
     }
 }

--- a/app/src/main/java/com/brentdunklau/telepatriot_android/DirectorActivity.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/DirectorActivity.java
@@ -2,6 +2,7 @@ package com.brentdunklau.telepatriot_android;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 
 import com.brentdunklau.telepatriot_android.com.brentdunklau.telepatriot_android.util.SlideIt;
 import com.brentdunklau.telepatriot_android.com.brentdunklau.telepatriot_android.util.SwipeAdapter;
@@ -13,55 +14,27 @@ import com.brentdunklau.telepatriot_android.com.brentdunklau.telepatriot_android
 
 public class DirectorActivity extends BaseActivity implements SlideIt {
 
+    private final static String TAG = "DirectoryActivity";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_director);
+        currentActivity = this.getClass();
         swipeAdapter = new SwipeAdapter(this, this);
         user = User.getInstance();
-    }
-
-
-    private Class onTheLeft() {
-        return user.activityOnTheLeft(DirectorActivity.class);
-    }
-
-
-    private Class onTheRight() {
-        return user.activityOnTheRight(DirectorActivity.class);
-    }
-
-
-    @Override
-    public void rightToLeft() {
-        Class onTheRight = onTheRight();
-        if(onTheRight != null) {
-            Intent it = new Intent(this, onTheRight());
-            startActivity(it);
-            overridePendingTransition(R.anim.slide_from_right, R.anim.slide_to_left);
-        }
-    }
-
-    @Override
-    public void leftToRight() {
-        Class onTheLeft = onTheLeft();
-        if(onTheLeft != null) {
-            Intent it = new Intent(this, onTheLeft());
-            startActivity(it);
-            overridePendingTransition(R.anim.slide_from_left, R.anim.slide_to_right);
-        }
-    }
-
-/*
-    @Override
-    protected void onPause() {
-        super.onPause();
-        Log.d("DirectorActivity", "paused");
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-        Log.d("DirectorActivity", "resume");
-    }*/
+        currentActivity = this.getClass();
+        Log.d(TAG, "resume");
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        currentActivity = this.getClass();
+    }
 }

--- a/app/src/main/java/com/brentdunklau/telepatriot_android/LimboActivity.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/LimboActivity.java
@@ -66,7 +66,6 @@ public class LimboActivity extends BaseActivity {
         };
 
         accountStatusEvents.setAdapter(mAdapter);
-
     }
 
     @Override

--- a/app/src/main/java/com/brentdunklau/telepatriot_android/MainActivity.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/MainActivity.java
@@ -26,7 +26,7 @@ public class MainActivity extends BaseActivity implements SlideIt
 {
 
     private static final int RC_SIGN_IN = 1;
-    protected String TAG = "MainActivity";
+    private static final String TAG = "MainActivity";
     public static final String ANONYMOUS = "anonymous";
 
     private String dataTitle, dataMessage;
@@ -36,6 +36,7 @@ public class MainActivity extends BaseActivity implements SlideIt
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        currentActivity = this.getClass();
         /**
          * see:  https://stackoverflow.com/a/11656129
          */
@@ -166,12 +167,17 @@ public class MainActivity extends BaseActivity implements SlideIt
             if(resultCode == RESULT_OK) {
                 user = User.getInstance();
                 user.login(mFirebaseAuth.getCurrentUser());
-                updateLabel(R.id.name, user.getName());
-                // user logged in
-                Log.d(TAG, mFirebaseAuth.getCurrentUser().getEmail());
+                String name = user.getName();
 
-                //Intent it = new Intent(this, LimboActivity.class);
-                //startActivity(it);
+                // Oops - this causes the app to crash.  I guess because we set the text of a label
+                // in a Runnable and by the time the Runnable gets called, we have moved on to the LimboActivity ...?
+                // Is that it?  Seems like it.  Everything seems to work when this 1 line below is commented out
+                //updateLabel(R.id.name, name);
+                // user logged in
+                //Log.d(TAG, mFirebaseAuth.getCurrentUser().getEmail());
+
+                Intent it = new Intent(this, LimboActivity.class);
+                startActivity(it);
 
 
 
@@ -203,52 +209,27 @@ public class MainActivity extends BaseActivity implements SlideIt
                 subscribeToTopics();
                  *************/
 
+
             } else {
                 // user not authenticated
                 Log.d(TAG, "USER NOT AUTHENTICATED");
             }
-        }
-    }
 
-
-    // NOTICE THAT WE PUT THIS IN THE SUPERCLASS
-    /*// 1:00  https://www.youtube.com/watch?v=VKbEfhf1qc&list=PL6gx4Cwl9DGBsvRxJJOzG4r4k_zLKrnxl&index=22
-    @Override
-    public boolean onTouchEvent(MotionEvent event) {
-        this.swipeAdapter.onTouchEvent(event);
-        return super.onTouchEvent(event);
-    }*/
-
-
-    private Class onTheLeft() {
-        return user.activityOnTheLeft(MainActivity.class);
-    }
-
-    private Class onTheRight() {
-        return user.activityOnTheRight(MainActivity.class);
-    }
-
-
-    @Override
-    public void rightToLeft() {
-        Class onTheRight = onTheRight();
-        if(onTheRight != null) {
-            Intent it = new Intent(this, onTheRight());
-            startActivity(it);
-            overridePendingTransition(R.anim.slide_from_right, R.anim.slide_to_left);
         }
     }
 
     @Override
-    public void leftToRight() {
-        Class onTheLeft = onTheLeft();
-        if(onTheLeft != null) {
-            Intent it = new Intent(this, onTheLeft());
-            startActivity(it);
-            overridePendingTransition(R.anim.slide_from_left, R.anim.slide_to_right);
-        }
+    protected void onResume() {
+        super.onResume();
+        currentActivity = this.getClass();
+        Log.d(TAG, "resume");
     }
 
+    @Override
+    protected void onStart() {
+        super.onStart();
+        currentActivity = this.getClass();
+    }
 
     /*
 

--- a/app/src/main/java/com/brentdunklau/telepatriot_android/com/brentdunklau/telepatriot_android/util/SwipeAdapter.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/com/brentdunklau/telepatriot_android/util/SwipeAdapter.java
@@ -19,15 +19,13 @@ public class SwipeAdapter implements GestureDetector.OnGestureListener {
     // 7:00  https://www.youtube.com/watch?v=zsNpiOihNXU&index=21&list=PL6gx4Cwl9DGBsvRxJJOzG4r4k_zLKrnxl
     private GestureDetectorCompat gestureDetector;
     private Context ctx;
-    //private WhereYouAre whereYouAre;
     private SlideIt slideIt;
 
 
-    public SwipeAdapter(Context ctx, /*WhereYouAre whereYouAre, */SlideIt slideIt) {
+    public SwipeAdapter(Context ctx, SlideIt slideIt) {
         // 9:00  https://www.youtube.com/watch?v=zsNpiOihNXU&index=21&list=PL6gx4Cwl9DGBsvRxJJOzG4r4k_zLKrnxl
         this.gestureDetector = new GestureDetectorCompat(ctx, this);
         this.ctx = ctx;
-        //this.whereYouAre = whereYouAre;
         this.slideIt = slideIt;
     }
 


### PR DESCRIPTION
…because I found a way to make the swipe-left and swipe-right code common.  Just created a 'currentActivity' protected field in BaseActivity.  Then in each of the subclasses set currentActivity equal to whatever class we're in.

Also fixed a bug in MainActivity.onActivityResult().  Turns out we were trying to set the text of a label on MainActivity using a Runnable.  And we were doing this right before we were switching over to LimboActivity.  So what happened - the app would crash, presumably because findViewById() was returning null since we were now on LimboActivity.