### PR TITLE
BUG FIX:  When looking at the user list for a given role, if there we…

### DIFF
--- a/app/src/main/java/com/brentdunklau/telepatriot_android/UserListFragment.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/UserListFragment.java
@@ -60,28 +60,16 @@ public class UserListFragment extends Fragment {
     }
 
     public void setRole(String role) {
-        updateLabel(view, R.id.role_header, role);
+        updateLabel(view, R.id.role_header, role+"s");
 
         final DatabaseReference ref = database.getReference("roles/"+role+"/users");
         ref.orderByChild("name")/*.limitToFirst(25) limit somehow? */.addListenerForSingleValueEvent(new ValueEventListener() {
             @Override
             public void onDataChange(DataSnapshot dataSnapshot) {
-                if(dataSnapshot.getValue() == null) {
-                    // print a "Your Work is Done" message
-                    // All users are in a role
-                    String workIsDone = "Your work is done here. All users have been assigned to at least one group.";
-                    updateLabel(view, R.id.txt_explanation, workIsDone);
-                }
-                else {
-                    // this is the case where we have some new users that need to be assigned to a role
-                    doit(ref);
-                }
+                doit(ref);
             }
-
             @Override
-            public void onCancelled(DatabaseError databaseError) {
-
-            }
+            public void onCancelled(DatabaseError databaseError) {}
         });
     }
 

--- a/app/src/main/res/layout/activity_listusers.xml
+++ b/app/src/main/res/layout/activity_listusers.xml
@@ -13,12 +13,15 @@
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="#ddffffff"
-        android:orientation="vertical">
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="0dp"
+        android:background="#ccffffff"
+        android:orientation="vertical"
+        android:id="@+id/top_menu_layout">
 
         <TextView
             android:id="@+id/text_admin"
+            android:text="Admin"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
@@ -26,16 +29,16 @@
             android:layout_marginTop="10dp"
             android:layout_marginLeft="10dp"
             android:layout_marginStart="10dp"
-            android:onClick="onClickRole"
-            android:text="Admin" />
+            android:layout_marginBottom="20dp"
+            android:onClick="onClickRole" />
 
 
 
         <TextView
             android:id="@+id/text_director"
+            android:text="Director"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Director"
             android:layout_alignBottom="@+id/text_admin"
             android:layout_centerHorizontal="true"
             android:onClick="onClickRole"
@@ -44,9 +47,9 @@
 
         <TextView
             android:id="@+id/text_volunteer"
+            android:text="Volunteer"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Volunteer"
             android:layout_marginRight="10dp"
             android:layout_marginEnd="10dp"
             android:layout_alignBottom="@+id/text_director"
@@ -60,9 +63,9 @@
         android:name="com.brentdunklau.telepatriot_android.UserListFragment"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="46dp"
+        android:layout_marginTop="0dp"
         tools:layout="@layout/user_list_fragment"
-        android:layout_below="@+id/text_admin"
+        android:layout_below="@+id/top_menu_layout"
         android:layout_alignParentLeft="true"
         android:layout_alignParentStart="true" />
 


### PR DESCRIPTION
…ren't any users with that role, the recyclerview would display the last list that we looked at instead.  So say Volunteers was empty, but that the last list you looked at was the list of Directors.  If you clicked on Volunteers, you would still see the list of Directors.  Made it look like there WERE Volunteers but there weren't.

Now, if you click on a role and there isn't anyone with that role, you just see the role as a header and then nothing underneath.