### PR TITLE
Bug Fix in the login process.  When established users were logging in…

### DIFF
--- a/app/src/main/java/com/brentdunklau/telepatriot_android/LauncherActivity.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/LauncherActivity.java
@@ -63,15 +63,16 @@ public class LauncherActivity extends BaseActivity implements AccountStatusEvent
         super.onActivityResult(requestCode, resultCode, data);
         if(requestCode == RC_SIGN_IN) {
             if(resultCode == RESULT_OK) {
-
-                ////////////////////////////////////////////////////////////////////////////////
-                // What if the user has no roles yet?  They need to go to the LimboActivity screen
-                ////////////////////////////////////////////////////////////////////////////////
-
-                //startActivity(new Intent(this, MainActivity.class));
-
-
-                User.getInstance().addAccountStatusEventListener(this);
+                if(User.getInstance().hasAnyRole()) {
+                    startActivity(new Intent(this, MainActivity.class));
+                }
+                else {
+                    // We only do this if the user is brand new and doesn't have any roles yet.
+                    // When the user is brand new, we send them to the LimboActivity screen
+                    // where they just have to sit and wait for an admin to let them in.
+                    // Look at fired(AccountStatusEvent evt) below...
+                    User.getInstance().addAccountStatusEventListener(this);
+                }
 
             } else {
                 // user not authenticated
@@ -82,6 +83,8 @@ public class LauncherActivity extends BaseActivity implements AccountStatusEvent
     }
 
     // per AccountStatusEvent.Listener
+    // This is what gets called by virtue of this call
+    //    above: User.getInstance().addAccountStatusEventListener(this);
     @Override
     public void fired(AccountStatusEvent evt) {
         if(evt instanceof AccountStatusEvent.NoRoles)

--- a/app/src/main/java/com/brentdunklau/telepatriot_android/util/User.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/util/User.java
@@ -258,6 +258,10 @@ public class User implements FirebaseAuth.AuthStateListener {
         return isVolunteer && !isDirector && !isAdmin;
     }
 
+    public boolean hasAnyRole() {
+        return isAdmin || isDirector || isVolunteer;
+    }
+
     @Override
     public void onAuthStateChanged(@NonNull FirebaseAuth firebaseAuth) {
         FirebaseUser firebaseUser = firebaseAuth.getCurrentUser();


### PR DESCRIPTION
…, they weren't being sent anywhere because where we were sending them next was based on an AccountStatusEvent.  But no AccountStatusEvent is being fired for established users.