### PR TITLE
Added an alert on the video chat screen to prevent the user from acci…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
         applicationId "com.brentdunklau.telepatriot_android"
         minSdkVersion 17
         targetSdkVersion 26
-        versionCode 46
+        versionCode 47
         versionName "${versionCode}"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/app/release/output.json
+++ b/app/release/output.json
@@ -1,1 +1,1 @@
-[{"outputType":{"type":"APK"},"apkInfo":{"type":"MAIN","splits":[],"versionCode":46,"versionName":"46","enabled":true,"outputFile":"app-release.apk","fullName":"release","baseName":"release"},"path":"app-release.apk","properties":{}}]
+[{"outputType":{"type":"APK"},"apkInfo":{"type":"MAIN","splits":[],"versionCode":47,"versionName":"47","enabled":true,"outputFile":"app-release.apk","fullName":"release","baseName":"release"},"path":"app-release.apk","properties":{}}]

--- a/app/src/main/java/com/brentdunklau/telepatriot_android/VidyoChatFragment.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/VidyoChatFragment.java
@@ -2034,6 +2034,28 @@ public class VidyoChatFragment extends BaseFragment
             return;
         }
 
+        if(currentVideoNode.getRoom_id() != null && currentVideoNode.getRoom_sid() != null) {
+            boolean previousRecordingExists = currentVideoNode.getRecording_stopped() != null;
+            if(previousRecordingExists) {
+
+                DialogInterface.OnClickListener l = new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        doRecording();
+                    }
+                };
+
+                Util.simpleOKCancelDialog(myView.getContext(), "Erase Recording?", "Do you want to record over the video you just created?", "Record Over", "Keep", l);
+            }
+            else {
+                doRecording();
+            }
+        }
+        else {
+            simpleOKDialog("Recording is currently disabled");
+        }
+    }
+
+    private void doRecording() {
         if (currentVideoNode.recordingHasNotStarted() || currentVideoNode.recordingHasStopped()) {
             record_label.setText("Recording will start momentarily");
             recordingWillStart = true;

--- a/app/src/main/java/com/brentdunklau/telepatriot_android/util/Util.java
+++ b/app/src/main/java/com/brentdunklau/telepatriot_android/util/Util.java
@@ -101,12 +101,17 @@ public class Util {
 
 
     public static void simpleOKCancelDialog(Context ctx, String title, String message, DialogInterface.OnClickListener l) {
+        simpleOKCancelDialog(ctx, title, message, "OK", "Cancel", l);
+    }
+
+
+    public static void simpleOKCancelDialog(Context ctx, String title, String message, String positiveButton, String negativeButton, DialogInterface.OnClickListener l) {
         AlertDialog.Builder builder = new AlertDialog.Builder(ctx);
         builder.setMessage(message)
                 .setTitle(title)
                 .setCancelable(true)
-                .setPositiveButton("OK", l)
-                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                .setPositiveButton(positiveButton, l)
+                .setNegativeButton(negativeButton, new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog, int id) {
                     // User cancelled the dialog
                     // nothing to do here - the dialog closes by default
@@ -131,5 +136,6 @@ public class Util {
             System.out.println(email+" is valid: "+valid(email));
         }
     }
+
 
 }


### PR DESCRIPTION
…dentally recording over a video call.  When a video call is completed, the user can publish the recording to YouTube.  But the record button is right next to the publish button.  So in case the user presses the record button when he really meant to press the upload button, we now have an alert that pops up a confirmation box to make sure the user doesn't accidentally record over the recording he just made