### PR TITLE
Temporary Modification to the way we manage teams.  The /manageTeams …

### DIFF
--- a/firebase-functions/functions/index.js
+++ b/firebase-functions/functions/index.js
@@ -49,8 +49,8 @@ const masterSpreadsheetReader = require('./sheets/import-master-sheet')
 exports.readMasterSpreadsheet = masterSpreadsheetReader.readMasterSpreadsheet
 exports.testReadMasterSpreadsheet = masterSpreadsheetReader.testReadMasterSpreadsheet
 
-// dev deploy:  11/12/18
-// prod deploy:  11/12/18
+// dev deploy:  11/18/18
+// prod deploy: 11/18/18
 const teams = require('./teams')
 exports.manageTeams = teams.manageTeams // contains links to all the other team functions
 exports.copyTeam = teams.copyTeam
@@ -76,6 +76,9 @@ exports.updateTeamListUnderUsers = teams.updateTeamListUnderUsers
 exports.viewMissionReport = teams.viewMissionReport
 exports.cullTrainingTeam = teams.cullTrainingTeam
 exports.removeFromTrainingTeam = teams.removeFromTrainingTeam
+exports.teamlist = teams.teamlist
+exports.addToTeamList = teams.addToTeamList
+exports.removeTeamFromList = teams.removeTeamFromList
 
 
 // prod deploy: 9/12/18, 9/20/18


### PR DESCRIPTION
…page was crashing more regularly because when we pull down /teams, we're pulling down a LOT of data.  So instead of pulling down everything under /teams, we instead created /team_list and store just the team names there, so that we can display the list of teams without having to pull down everything under /teams.